### PR TITLE
[Feature Request] Add time string each line when -o specified

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -652,7 +652,7 @@ func removeColor(out string) string {
 func getMetricForFile(now int, old int, title *string, content *string, nowTime string, outputTitle int) string {
 	var out string
 	if now == old && outputTitle != 1 {
-		out = fmt.Sprintf("%s\n%s", nowTime, *content)
+		out = fmt.Sprintf("%s\n%s", nowTime, strings.Replace(*content, "\n", "\n" + nowTime + "\t", -1))
 	} else {
 		out = *title + *content
 	}


### PR DESCRIPTION
This is feature request.

My patch is adding time string each line when `-o` is specified.
Output file sample are below.

## AS-IS

```
$ ./myStatusgo -hc 127.0.0.1:64080 -u yoku0825 -p 'abc' -a -c 10 -o before.log 
$ cat before.log
..
2022-01-13 19:21:36
127.0.0.1:64080
------------------------------------------- QPS ------------------------------------------------------------------------ ------- CPU ------- -- Disk - -- NW --- ---load-avg--- ------ memory ----  - swap --
Conn Run Abort Select Update Insert Delete Replace Qcache Call QPSAll StmtExc Commit Rolbk Slow Ssum Read  Delay  IO SQL usr sys wai irq idl read writ recv send  1m   5m   15m used buff cach free swap free
---- --- ----- ------ ------ ------ ------ ------- ------ ---- ------ ------- ------ ----- ---- ---- ---- ------ --- --- --- --- --- --- --- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
   1   2     0      6      0      0      0       0      0    0      6       0      0     0   11   23  OFF                 -1
<snip>
```

## TO-BE

```
$ ./myStatusgo -hc 127.0.0.1:64080 -u yoku0825 -p 'abc' -a -c 10 -o after.log 
$ cat after.log
..
2022-01-13 19:26:21
127.0.0.1:64080
2022-01-13 19:26:21     ------------------------------------------- QPS ------------------------------------------------------------------------ ------- CPU ------- -- Disk - -- NW --- ---load-avg--- ------ memory ----  - swap --
2022-01-13 19:26:21     Conn Run Abort Select Update Insert Delete Replace Qcache Call QPSAll StmtExc Commit Rolbk Slow Ssum Read  Delay  IO SQL usr sys wai irq idl read writ recv send  1m   5m   15m used buff cach free swap free
2022-01-13 19:26:21     ---- --- ----- ------ ------ ------ ------ ------- ------ ---- ------ ------- ------ ----- ---- ---- ---- ------ --- --- --- --- --- --- --- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
2022-01-13 19:26:21        1   2     0      6      0      0      0       0      0    0      6       0      0     0   13   35  OFF                 -1
2022-01-13 19:26:21
2022-01-13 19:26:21      ------------ InnoDB Rows ---------- -----------------------------------------------Handlar--------------------------------------------------------------
2022-01-13 19:26:21        read   inserted  updated  deleted  RdFirst   RdKey   RdLast    RdNxt   RdPrev    RdRnd  RdRndNxt   Write   Update   Delete   Prepare  Commit  Rollback
2022-01-13 19:26:21      -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- -------- --------
2022-01-13 19:26:21             0        0        0        0        0       63        0        4        0        0     1634      912        5        0        0        0        0
2022-01-13 19:26:21
2022-01-13 19:26:21     -------------------------------------------------- InnoDB Buffer Pool Info ----------------------------------------------------
2022-01-13 19:26:21      Total  Data   Dirty  Free   DataPage DirtyPage  FreePage MiscPag   Read   RdReq  WritReq Writen Create  Flush LSN-CK  HitRate
2022-01-13 19:26:21     ------ ------ ------ ------ --------- --------- --------- ------- ------- ------- ------- ------ ------ ------ ------ ---------
2022-01-13 19:26:21       134M    16M      0   118M       970         0      7217       5       0       0       0      0      0      0      0 100.0/100
2022-01-13 19:26:21
2022-01-13 19:26:21     - ------------------------------- Thread Info ----------------------------------------------------------------------------------------------------------
2022-01-13 19:26:21     *  Cmd            State          User        Host         DB    Time   Query
2022-01-13 19:26:21     - ------- -------------------- ------- --------------- ------- ----- -----------------------------------------------------------------------------------
2022-01-13 19:26:21     *
2022-01-13 19:26:21     *
2022-01-13 19:26:21     *
2022-01-13 19:26:21     *
2022-01-13 19:26:21     *
<snip>
```

Actually, this is incompatible change.
Should I make another option (like `-output-with-time` ) instead of patching `getMetricForFile` directly?